### PR TITLE
V2 multiple viewports

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Next, register Addon.
 
 ```javascript
 // Other addons...
-import 'storybook-chrome-screenshot/register';
+import "storybook-chrome-screenshot/register";
 ```
 
 ### Register initialization process
@@ -90,8 +90,8 @@ Add [initScreenshot](#initscreenshot) decorator. It has to be **before** the fir
 **Example: .storybook/config.js**
 
 ```javascript
-import { addDecorator } from '@storybook/react';
-import { initScreenshot } from 'storybook-chrome-screenshot';
+import { addDecorator } from "@storybook/react";
+import { initScreenshot } from "storybook-chrome-screenshot";
 
 addDecorator(initScreenshot());
 ```
@@ -103,12 +103,12 @@ Create a story with [withScreenshot](#withscreenshotoptions--).
 #### React
 
 ```javascript
-import React from 'react';
-import { storiesOf } from '@storybook/react';
-import { withScreenshot } from 'storybook-chrome-screenshot';
-import Button from './Button';
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { withScreenshot } from "storybook-chrome-screenshot";
+import Button from "./Button";
 
-storiesOf('Button', module).add('with text', withScreenshot()(() => <Button>Text</Button>));
+storiesOf("Button", module).add("with text", withScreenshot()(() => <Button>Text</Button>));
 ```
 
 #### Angular
@@ -116,18 +116,18 @@ storiesOf('Button', module).add('with text', withScreenshot()(() => <Button>Text
 This function works well even if you use Angular:
 
 ```javascript
-import { storiesOf } from '@storybook/angular';
-import { withScreenshot } from 'storybook-chrome-screenshot';
-import { MyButtonComponent } from '../src/app/my-button/my-button.component';
+import { storiesOf } from "@storybook/angular";
+import { withScreenshot } from "storybook-chrome-screenshot";
+import { MyButtonComponent } from "../src/app/my-button/my-button.component";
 
-storiesOf('Button', module).add(
-  'with custom label',
+storiesOf("Button", module).add(
+  "with custom label",
   withScreenshot()(() => ({
     component: MyButtonComponent,
     props: {
-      text: 'Text'
-    }
-  }))
+      text: "Text",
+    },
+  })),
 );
 ```
 
@@ -136,29 +136,29 @@ storiesOf('Button', module).add(
 Of course, Vue.js works the same way:
 
 ```javascript
-import { storiesOf } from '@storybook/vue';
-import { withScreenshot } from 'storybook-chrome-screenshot';
-import MyButton from './Button.vue';
+import { storiesOf } from "@storybook/vue";
+import { withScreenshot } from "storybook-chrome-screenshot";
+import MyButton from "./Button.vue";
 
-storiesOf('MyButton', module)
+storiesOf("MyButton", module)
   .add(
-    'pre-registered component',
+    "pre-registered component",
     withScreenshot()(() => ({
-      template: '<my-button :rounded="true">A Button with rounded edges</my-button>'
-    }))
+      template: '<my-button :rounded="true">A Button with rounded edges</my-button>',
+    })),
   )
   .add(
-    'template + component',
+    "template + component",
     withScreenshot()(() => ({
       components: { MyButton },
-      template: '<my-button>Button rendered in a template</my-button>'
-    }))
+      template: "<my-button>Button rendered in a template</my-button>",
+    })),
   )
   .add(
-    'render + component',
+    "render + component",
     withScreenshot()(() => ({
-      render: (h) => h(MyButton, { props: { color: 'pink' } }, ['renders component: MyButton'])
-    }))
+      render: h => h(MyButton, { props: { color: "pink" } }, ["renders component: MyButton"]),
+    })),
   );
 ```
 
@@ -187,17 +187,17 @@ $ npm run screenshot
 Or by using `addDecorator()`, it is possible to shotting all the decorated stories.
 
 ```javascript
-import { storiesOf } from '@storybook/react';
-import { withScreenshot } from 'storybook-chrome-screenshot';
+import { storiesOf } from "@storybook/react";
+import { withScreenshot } from "storybook-chrome-screenshot";
 
-storiesOf('Button', module)
+storiesOf("Button", module)
   .addDecorator(
     withScreenshot({
       /* ...options */
-    })
+    }),
   )
-  .add('with primary', () => <Button primary>Primary Button</Button>)
-  .add('with secondary', () => <Button secondary>Secondary Button</Button>);
+  .add("with primary", () => <Button primary>Primary Button</Button>)
+  .add("with secondary", () => <Button secondary>Secondary Button</Button>);
 ```
 
 ## API
@@ -211,8 +211,8 @@ This decorator has to be added to every story. Addon uses it to understand when 
 **Example: .storybook/config.js**
 
 ```javascript
-import { addDecorator } from '@storybook/react';
-import { initScreenshot } from 'storybook-chrome-screenshot';
+import { addDecorator } from "@storybook/react";
+import { initScreenshot } from "storybook-chrome-screenshot";
 
 addDecorator(initScreenshot());
 ```
@@ -276,14 +276,14 @@ It is useful for changing Viewport of all stories.
 **Example: .storybook/config.js**
 
 ```javascript
-import { setScreenshotOptions } from 'storybook-chrome-screenshot';
+import { setScreenshotOptions } from "storybook-chrome-screenshot";
 
 setScreenshotOptions({
   viewport: {
     width: 768,
     height: 400,
-    deviceScaleFactor: 2
-  }
+    deviceScaleFactor: 2,
+  },
 });
 ```
 
@@ -292,14 +292,16 @@ setScreenshotOptions({
 Get the current option used with [withScreenshot()](#withscreenshotoptions--).
 
 ```javascript
-import { getScreenshotOptions } from 'storybook-chrome-screenshot';
+import { getScreenshotOptions } from "storybook-chrome-screenshot";
 
 console.log(getScreenshotOptions());
 // => Current screenshot options...
 ```
 
 ## Command Line Options
+
 <!-- inject:clihelp -->
+
 ```txt
 usage: storycap [options] storybook_url
 
@@ -311,7 +313,7 @@ Options:
   --flat, -f                   Flatten output filename.                                       [boolean] [default: false]
   --include, -i                Including stories name rule.                                        [array] [default: []]
   --exclude, -e                Excluding stories name rule.                                        [array] [default: []]
-  --viewport, -V               Default viewport.                                           [string] [default: "800x600"]
+  --viewport, -V               Viewport.                                                  [array] [default: ["800x600"]]
   --disableCssAnimation        Disable CSS animation and transition.                           [boolean] [default: true]
   --silent                                                                                    [boolean] [default: false]
   --verbose                                                                                   [boolean] [default: false]
@@ -325,11 +327,13 @@ Options:
 
 Examples:
   storycap http://localshot:9009
+  storycap http://localshot:9009 -V 1024x768 -V 320x568
   storycap http://localshot:9009 -i "some-kind/a-story"
   storycap http://example.com/your-storybook -e "**/default" -V iPad
   storycap --serverCmd "start-storybook -p 3000" http://localshot:3000
 
 ```
+
 <!-- endinject -->
 
 ## Tips
@@ -342,9 +346,9 @@ You can create `./disable-animation.js` and disable CSS Animation with the next 
 
 ```javascript
 (() => {
-  const $iframe = document.getElementById('storybook-preview-iframe');
+  const $iframe = document.getElementById("storybook-preview-iframe");
   const $doc = $iframe.contentDocument;
-  const $style = $doc.createElement('style');
+  const $style = $doc.createElement("style");
 
   $style.innerHTML = `* {
     transition: none !important;
@@ -370,27 +374,27 @@ For example, the following setting makes the screenshot function wait for firing
 
 ```html
 <!-- ./storybook/preview-head.html -->
-<link rel="preload" href="/some-heavy-asset.woff" as="font" onload="this.setAttribute('loaded', 'loaded')">
+<link rel="preload" href="/some-heavy-asset.woff" as="font" onload="this.setAttribute('loaded', 'loaded')" />
 <script>
-function fontLoading() {
-  const loaded = () => !!document.querySelector('link[rel="preload"][loaded="loaded"]');
-  if (loaded()) return Promise.resolve();
-  return new Promise((resolve, reject) => {
-    const id = setInterval(() => {
-      if (!loaded()) return;
-      clearInterval(id);
-      resolve();
-    }, 50);
-  });
-}
+  function fontLoading() {
+    const loaded = () => !!document.querySelector('link[rel="preload"][loaded="loaded"]');
+    if (loaded()) return Promise.resolve();
+    return new Promise((resolve, reject) => {
+      const id = setInterval(() => {
+        if (!loaded()) return;
+        clearInterval(id);
+        resolve();
+      }, 50);
+    });
+  }
 </script>
 ```
 
 ```javascript
-import { setScreenshotOptions } from 'storybook-chrome-screenshot';
+import { setScreenshotOptions } from "storybook-chrome-screenshot";
 
 setScreenshotOptions({
-  waitFor: 'fontLoading',
+  waitFor: "fontLoading",
 });
 ```
 

--- a/examples/v5-managed-react/.storybook/config.js
+++ b/examples/v5-managed-react/.storybook/config.js
@@ -8,9 +8,17 @@ function loadStories() {
 addDecorator(withScreenshot);
 addParameters({
   screenshot: {
-    viewport: {
-      width: 1200,
-      height: 800,
+    viewports: {
+      LARGE: {
+        width: 1200,
+        height: 800,
+      },
+      SMALL: {
+        width: 375,
+        height: 667,
+        deviceScaleFactor: 2,
+        isMobile: true,
+      },
     },
   },
 });

--- a/examples/v5-managed-react/src/stories/index.js
+++ b/examples/v5-managed-react/src/stories/index.js
@@ -12,7 +12,7 @@ storiesOf('Welcome_override', module)
   screenshot: {
     viewport: 'iPhone 6',
     variants: {
-      xs: {
+      XSMALL: {
         viewport: 'iPhone 5',
       },
     },

--- a/examples/v5-simple/package.json
+++ b/examples/v5-simple/package.json
@@ -16,7 +16,7 @@
     "storybook": "start-storybook -p 9009 -s public",
     "build-storybook": "build-storybook -s public",
     "prestorybook": "../../scripts/e2e-prestorybook.js .",
-    "storycap:all": "yarn prestorybook && storycap --server-cmd \"start-storybook -p 9009 -s public\" \"http://localhost:9009\""
+    "storycap:all": "yarn prestorybook && storycap --server-cmd \"start-storybook -p 9009 -s public\" \"http://localhost:9009\" -V \"iPad\" -V \"iPhone 6\""
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/client/capture.ts
+++ b/src/client/capture.ts
@@ -2,8 +2,7 @@ import { ExposedWindow } from "../node/types";
 import { ScreenshotOptions } from "./types";
 import imagesloaded from "imagesloaded";
 import { sleep } from "../util";
-import { defaultScreenshotOptions } from "./default-screenshot-options";
-import { mergeScreenshotOptions, pickupFromVariantKey } from "../util/screenshot-options-helper";
+import { mergeScreenshotOptions, pickupFromVariantKey, expandViewportsOption } from "../util/screenshot-options-helper";
 
 function waitImages(enabled: boolean, selector = "body") {
   if (!enabled) return Promise.resolve();
@@ -59,14 +58,18 @@ export function stock(opt: Partial<ScreenshotOptions> = {}) {
 
 export function capture() {
   withExpoesdWindow(win => {
-    Promise.all([win.getCurrentStoryKey(location.href), win.getCurrentVariantKey()]).then(([storyKey, vk]) => {
+    Promise.all([
+      win.getBaseScreenshotOptions(),
+      win.getCurrentStoryKey(location.href),
+      win.getCurrentVariantKey(),
+    ]).then(([baseScreenshotOptions, storyKey, vk]) => {
       if (!storyKey) return;
       const options = consumeOptions(win, storyKey);
       if (!options) return;
       const scOpt = pickupFromVariantKey(
         options.reduce(
-          (acc: ScreenshotOptions, opt: ScreenshotOptions) => mergeScreenshotOptions(acc, opt),
-          defaultScreenshotOptions,
+          (acc: ScreenshotOptions, opt: ScreenshotOptions) => mergeScreenshotOptions(acc, expandViewportsOption(opt)),
+          baseScreenshotOptions,
         ),
         vk,
       );

--- a/src/client/default-screenshot-options.ts
+++ b/src/client/default-screenshot-options.ts
@@ -1,8 +1,0 @@
-export const defaultScreenshotOptions = {
-  delay: 0,
-  waitImages: true,
-  waitFor: "",
-  fullPage: true,
-  skip: false,
-  variants: {},
-} as const;

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -25,15 +25,18 @@ export interface ScreenshotOptionFragmentsForVariant extends ScreenshotOptionFra
 }
 
 export interface ScreenshotOptions extends ScreenshotOptionFragments {
+  viewports?: string[] | { [key: string]: string | Viewport };
   variants?: {
     [key: string]: ScreenshotOptionFragmentsForVariant;
   };
+  defaultVariantSuffix?: string;
 }
 
 export interface StrictScreenshotOptions extends $Strict<ScreenshotOptionFragments> {
   variants: {
     [key: string]: $Strict<ScreenshotOptionFragmentsForVariant>;
   };
+  defaultVariantSuffix: string;
 }
 
 export type ScreenshotOptionsForApp = StrictScreenshotOptions & {

--- a/src/node/capturing-browser.ts
+++ b/src/node/capturing-browser.ts
@@ -12,6 +12,7 @@ import {
   createBaseScreenshotOptions,
   mergeScreenshotOptions,
   extractAdditionalVariantKeys,
+  pickupFromVariantKey,
 } from "../util/screenshot-options-helper";
 import { sleep } from "../util";
 const dd = require("puppeteer/DeviceDescriptors") as { name: string; viewport: Viewport }[];
@@ -33,6 +34,7 @@ export class CapturingBrowser extends StoryPreviewBrowser {
   private viewport?: Viewport;
   private emitter: EventEmitter;
   private readonly processedStories = new Set<string>();
+  private baseScreenshotOptions: StrictScreenshotOptions;
   private currentRequestId!: string;
   private currentVariantKey: VariantKey = { isDefault: true, keys: [] };
 
@@ -42,6 +44,7 @@ export class CapturingBrowser extends StoryPreviewBrowser {
     this.emitter.on("error", e => {
       throw e;
     });
+    this.baseScreenshotOptions = createBaseScreenshotOptions(opt);
   }
 
   async boot() {
@@ -80,6 +83,7 @@ $doc.body.appendChild($style);
     this.page.exposeFunction("emitCatpture", (opt: any, clientStoryKey: string) =>
       this.handleOnCapture(opt, clientStoryKey),
     );
+    this.page.exposeFunction("getBaseScreenshotOptions", () => this.baseScreenshotOptions);
     this.page.exposeFunction("getCurrentStoryKey", (url: string) => url2StoryKey(url));
     this.page.exposeFunction("getCurrentVariantKey", () => this.currentVariantKey);
   }
@@ -206,24 +210,24 @@ $doc.body.appendChild($style);
     this.currentRequestId = requestId;
     this.currentVariantKey = variantKey;
     this.currentStoryRetryCount = retryCount;
-    const baseScreenshotOptions = createBaseScreenshotOptions(this.opt);
     let emittedScreenshotOptions: ScreenshotOptions | undefined;
     if (this.mode === "managed") {
       emittedScreenshotOptions = await this.waitScreenShotOption();
       if (!this.currentStory) {
         throw new InvalidCurrentStoryStateError();
       }
-      if (!emittedScreenshotOptions || emittedScreenshotOptions.skip) {
-        return { buffer: null, succeeded: !!emittedScreenshotOptions, variantKeysToPush: [] };
-      } else if (!emittedScreenshotOptions.viewport) {
-        emittedScreenshotOptions.viewport = this.opt.defaultViewport;
+      if (!emittedScreenshotOptions) {
+        return { buffer: null, succeeded: false, variantKeysToPush: [], defaultVariantSuffix: "" };
+      }
+      if (emittedScreenshotOptions.skip) {
+        return { buffer: null, succeeded: true, variantKeysToPush: [], defaultVariantSuffix: "" };
       }
     } else {
-      emittedScreenshotOptions = {};
+      emittedScreenshotOptions = pickupFromVariantKey(this.baseScreenshotOptions, this.currentVariantKey);
     }
-    const mergedScreenshotOptions = mergeScreenshotOptions(baseScreenshotOptions, emittedScreenshotOptions);
+    const mergedScreenshotOptions = mergeScreenshotOptions(this.baseScreenshotOptions, emittedScreenshotOptions);
     const changed = await this.setViewport(mergedScreenshotOptions);
-    if (!changed) return { buffer: null, succeeded: true, variantKeysToPush: [] };
+    if (!changed) return { buffer: null, succeeded: true, variantKeysToPush: [], defaultVariantSuffix: "" };
     await this.waitBrowserMetricsStable();
     await this.page.evaluate(
       () => new Promise(res => (window as ExposedWindow).requestIdleCallback(() => res(), { timeout: 3000 })),
@@ -232,6 +236,11 @@ $doc.body.appendChild($style);
       ? extractAdditionalVariantKeys(mergedScreenshotOptions)
       : [];
     const buffer = await this.page.screenshot({ fullPage: emittedScreenshotOptions.fullPage });
-    return { buffer, succeeded: true, variantKeysToPush };
+    return {
+      buffer,
+      succeeded: true,
+      variantKeysToPush,
+      defaultVariantSuffix: emittedScreenshotOptions.defaultVariantSuffix,
+    };
   }
 }

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -17,7 +17,7 @@ function createOptions(): MainOptions {
     .option("flat", { boolean: true, alias: "f", default: false, description: "Flatten output filename." })
     .option("include", { array: true, alias: "i", default: [], description: "Including stories name rule." })
     .option("exclude", { array: true, alias: "e", default: [], description: "Excluding stories name rule." })
-    .option("viewport", { string: true, alias: "V", default: "800x600", description: "Default viewport." })
+    .option("viewport", { array: true, alias: "V", default: ["800x600"], description: "Viewport." })
     .option("disableCssAnimation", {
       boolean: true,
       default: true,
@@ -49,6 +49,7 @@ function createOptions(): MainOptions {
       description: "Whether to reload after viewport changed.",
     })
     .example("storycap http://localshot:9009", "")
+    .example("storycap http://localshot:9009 -V 1024x768 -V 320x568", "")
     .example('storycap http://localshot:9009 -i "some-kind/a-story"', "")
     .example('storycap http://example.com/your-storybook -e "**/default" -V iPad', "")
     .example('storycap --serverCmd "start-storybook -p 3000" http://localshot:3000', "");
@@ -89,7 +90,7 @@ function createOptions(): MainOptions {
     flat,
     include,
     exclude,
-    defaultViewport: viewport,
+    viewports: viewport,
     parallel,
     captureTimeout,
     captureMaxRetryCount,

--- a/src/node/types.ts
+++ b/src/node/types.ts
@@ -1,4 +1,4 @@
-import { ScreenshotOptions } from "../client/types";
+import { ScreenshotOptions, StrictScreenshotOptions } from "../client/types";
 import { Logger } from "./logger";
 import { StorybookServerOptions } from "./story-crawler";
 import { VariantKey } from "../types";
@@ -7,6 +7,7 @@ export type ExposedWindow = typeof window & {
   emitCatpture(opt: ScreenshotOptions, clientStoryKey: string): void;
   waitFor?: () => Promise<any>;
   requestIdleCallback(cb: Function, opt?: { timeout: number }): void;
+  getBaseScreenshotOptions: () => Promise<StrictScreenshotOptions>;
   getCurrentStoryKey: (url: string) => Promise<string | undefined>;
   getCurrentVariantKey: () => Promise<VariantKey>;
   optionStore?: { [storyKey: string]: (Partial<ScreenshotOptions>)[] };
@@ -19,7 +20,7 @@ export interface MainOptions {
   serverOptions: StorybookServerOptions;
   captureTimeout: number;
   captureMaxRetryCount: number;
-  defaultViewport: string;
+  viewports: string[];
   viewportDelay: number;
   reloadAfterChangeViewport: boolean;
   outDir: string;

--- a/src/util/screenshot-options-helper.test.ts
+++ b/src/util/screenshot-options-helper.test.ts
@@ -1,4 +1,77 @@
-import { pickupFromVariantKey } from "./screenshot-options-helper";
+import { expandViewportsOption, pickupFromVariantKey } from "./screenshot-options-helper";
+
+describe(expandViewportsOption, () => {
+  it("should expand viewport and variants from viewports", () => {
+    expect(
+      expandViewportsOption({
+        viewports: ["iPad"],
+      }),
+    ).toEqual({
+      viewport: "iPad",
+      variants: {},
+    });
+
+    expect(
+      expandViewportsOption({
+        viewports: ["iPad", "iPhone6"],
+      }),
+    ).toEqual({
+      viewport: "iPad",
+      variants: {
+        iPhone6: {
+          viewport: "iPhone6",
+        },
+      },
+      defaultVariantSuffix: "iPad",
+    });
+
+    expect(
+      expandViewportsOption({
+        viewports: {
+          hoge: {
+            width: 1000,
+            height: 1000,
+          },
+        },
+      }),
+    ).toEqual({
+      viewport: {
+        width: 1000,
+        height: 1000,
+      },
+      variants: {},
+    });
+
+    expect(
+      expandViewportsOption({
+        viewports: {
+          hoge: {
+            width: 1000,
+            height: 1000,
+          },
+          bar: {
+            width: 500,
+            height: 500,
+          },
+        },
+      }),
+    ).toEqual({
+      viewport: {
+        width: 1000,
+        height: 1000,
+      },
+      variants: {
+        bar: {
+          viewport: {
+            width: 500,
+            height: 500,
+          },
+        },
+      },
+      defaultVariantSuffix: "hoge",
+    });
+  });
+});
 
 describe(pickupFromVariantKey, () => {
   it("should pass through with default variant", () => {


### PR DESCRIPTION
## What I did

This PR allows to configure multiple viewports.

- CLI accepts `-V` as an array
- ScreenshotOptions accepts `viewports` section

Multiple viewports should be expanded as one default viewport and viewport variants that represent the rest of them.

See also #95 