### PR TITLE
feat: allow to extend other variables

### DIFF
--- a/examples/v5-managed-react/src/stories/index.js
+++ b/examples/v5-managed-react/src/stories/index.js
@@ -52,6 +52,7 @@ storiesOf('MyButton', module)
     screenshot: {
       variants: {
         hover: {
+          extends: ['LARGE', 'SMALL'],
           hover: '.my-button',
         },
       },

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -23,7 +23,7 @@ export interface ScreenshotOptionFragments {
 }
 
 export interface ScreenshotOptionFragmentsForVariant extends ScreenshotOptionFragments {
-  followWith?: string[];
+  extends?: string | string[];
 }
 
 export interface ScreenshotOptions extends ScreenshotOptionFragments {

--- a/src/node/capturing-browser.ts
+++ b/src/node/capturing-browser.ts
@@ -11,7 +11,7 @@ import { VariantKey } from '../types';
 import {
   createBaseScreenshotOptions,
   mergeScreenshotOptions,
-  extractAdditionalVariantKeys,
+  extractVariantKeys,
   pickupFromVariantKey,
 } from '../util/screenshot-options-helper';
 import { sleep } from '../util';
@@ -274,7 +274,7 @@ $doc.body.appendChild($style);
     await this.page.evaluate(
       () => new Promise(res => (window as ExposedWindow).requestIdleCallback(() => res(), { timeout: 3000 })),
     );
-    const [invalidReason, keys] = extractAdditionalVariantKeys(mergedScreenshotOptions);
+    const [invalidReason, keys] = extractVariantKeys(mergedScreenshotOptions);
     if (invalidReason) {
       if (invalidReason.type === 'notFound') {
         this.logger.warn(

--- a/src/node/capturing-browser.ts
+++ b/src/node/capturing-browser.ts
@@ -274,9 +274,21 @@ $doc.body.appendChild($style);
     await this.page.evaluate(
       () => new Promise(res => (window as ExposedWindow).requestIdleCallback(() => res(), { timeout: 3000 })),
     );
-    const variantKeysToPush = this.currentVariantKey.isDefault
-      ? extractAdditionalVariantKeys(mergedScreenshotOptions)
-      : [];
+    const [invalidReason, keys] = extractAdditionalVariantKeys(mergedScreenshotOptions);
+    if (invalidReason) {
+      if (invalidReason.type === 'notFound') {
+        this.logger.warn(
+          `Invalid variants. The variant key '${invalidReason.to}' does not exist(story id: ${this.currentStory!.id}).`,
+        );
+      } else if (invalidReason.type === 'circular') {
+        this.logger.warn(
+          `Invalid variants. Reference ${invalidReason.refs.join(' -> ')} is circular(story id: ${
+            this.currentStory!.id
+          }).`,
+        );
+      }
+    }
+    const variantKeysToPush = this.currentVariantKey.isDefault ? keys : [];
     const buffer = await this.page.screenshot({ fullPage: emittedScreenshotOptions.fullPage });
     await this.resetIfTouched();
     return {

--- a/src/util/screenshot-options-helper.test.ts
+++ b/src/util/screenshot-options-helper.test.ts
@@ -1,4 +1,4 @@
-import { expandViewportsOption, pickupFromVariantKey, extractAdditionalVariantKeys } from './screenshot-options-helper';
+import { expandViewportsOption, pickupFromVariantKey, extractVariantKeys } from './screenshot-options-helper';
 
 describe(expandViewportsOption, () => {
   it('should expand viewport and variants from viewports', () => {
@@ -73,14 +73,14 @@ describe(expandViewportsOption, () => {
   });
 });
 
-describe(extractAdditionalVariantKeys, () => {
+describe(extractVariantKeys, () => {
   it('should return an empty array when options has no variants', () => {
-    expect(extractAdditionalVariantKeys({})).toEqual([null, []]);
+    expect(extractVariantKeys({})).toEqual([null, []]);
   });
 
   it('should extract variant keys from simple variants', () => {
     expect(
-      extractAdditionalVariantKeys({
+      extractVariantKeys({
         variants: {
           a: {},
         },
@@ -90,7 +90,7 @@ describe(extractAdditionalVariantKeys, () => {
 
   it('should extract variant keys expanding extension others', () => {
     expect(
-      extractAdditionalVariantKeys({
+      extractVariantKeys({
         variants: {
           a: {},
           b: {
@@ -114,7 +114,7 @@ describe(extractAdditionalVariantKeys, () => {
 
   it('should return keys with defaultVariantSuffix', () => {
     expect(
-      extractAdditionalVariantKeys({
+      extractVariantKeys({
         variants: {
           a: {
             extends: 'root',
@@ -127,7 +127,7 @@ describe(extractAdditionalVariantKeys, () => {
 
   it('should return invalid reason when target variant does not exist', () => {
     expect(
-      extractAdditionalVariantKeys({
+      extractVariantKeys({
         variants: {
           a: {},
           c: {
@@ -141,13 +141,13 @@ describe(extractAdditionalVariantKeys, () => {
         from: 'c',
         to: 'b',
       },
-      null,
+      [],
     ]);
   });
 
   it('should return invalid reason when circular reference', () => {
     expect(
-      extractAdditionalVariantKeys({
+      extractVariantKeys({
         variants: {
           a: {
             extends: 'c',
@@ -165,7 +165,7 @@ describe(extractAdditionalVariantKeys, () => {
         type: 'circular',
         refs: ['c', 'a', 'b', 'c'],
       },
-      null,
+      [],
     ]);
   });
 });

--- a/src/util/screenshot-options-helper.test.ts
+++ b/src/util/screenshot-options-helper.test.ts
@@ -1,4 +1,4 @@
-import { expandViewportsOption, pickupFromVariantKey } from './screenshot-options-helper';
+import { expandViewportsOption, pickupFromVariantKey, extractAdditionalVariantKeys } from './screenshot-options-helper';
 
 describe(expandViewportsOption, () => {
   it('should expand viewport and variants from viewports', () => {
@@ -73,6 +73,103 @@ describe(expandViewportsOption, () => {
   });
 });
 
+describe(extractAdditionalVariantKeys, () => {
+  it('should return an empty array when options has no variants', () => {
+    expect(extractAdditionalVariantKeys({})).toEqual([null, []]);
+  });
+
+  it('should extract variant keys from simple variants', () => {
+    expect(
+      extractAdditionalVariantKeys({
+        variants: {
+          a: {},
+        },
+      }),
+    ).toEqual([null, [{ isDefault: false, keys: ['a'] }]]);
+  });
+
+  it('should extract variant keys expanding extension others', () => {
+    expect(
+      extractAdditionalVariantKeys({
+        variants: {
+          a: {},
+          b: {
+            extends: 'a',
+          },
+          c: {
+            extends: ['b', 'a'],
+          },
+        },
+      }),
+    ).toEqual([
+      null,
+      [
+        { isDefault: false, keys: ['a'] },
+        { isDefault: false, keys: ['a', 'b'] },
+        { isDefault: false, keys: ['a', 'b', 'c'] },
+        { isDefault: false, keys: ['a', 'c'] },
+      ],
+    ]);
+  });
+
+  it('should return keys with defaultVariantSuffix', () => {
+    expect(
+      extractAdditionalVariantKeys({
+        variants: {
+          a: {
+            extends: 'root',
+          },
+        },
+        defaultVariantSuffix: 'root',
+      }),
+    ).toEqual([null, [{ isDefault: false, keys: ['root', 'a'] }]]);
+  });
+
+  it('should return invalid reason when target variant does not exist', () => {
+    expect(
+      extractAdditionalVariantKeys({
+        variants: {
+          a: {},
+          c: {
+            extends: 'b',
+          },
+        },
+      }),
+    ).toEqual([
+      {
+        type: 'notFound',
+        from: 'c',
+        to: 'b',
+      },
+      null,
+    ]);
+  });
+
+  it('should return invalid reason when circular reference', () => {
+    expect(
+      extractAdditionalVariantKeys({
+        variants: {
+          a: {
+            extends: 'c',
+          },
+          b: {
+            extends: 'a',
+          },
+          c: {
+            extends: 'b',
+          },
+        },
+      }),
+    ).toEqual([
+      {
+        type: 'circular',
+        refs: ['c', 'a', 'b', 'c'],
+      },
+      null,
+    ]);
+  });
+});
+
 describe(pickupFromVariantKey, () => {
   it('should pass through with default variant', () => {
     expect(
@@ -104,14 +201,41 @@ describe(pickupFromVariantKey, () => {
           variants: {
             k1: {
               delay: 100,
+              hover: 'fuga',
+            },
+            k2: {
+              hover: 'hoge',
             },
           },
         },
-        { isDefault: false, keys: ['k1'] },
+        { isDefault: false, keys: ['k1', 'k2'] },
+      ),
+    ).toEqual({
+      delay: 100,
+      hover: 'hoge',
+      viewport: 'iPhone 6',
+    });
+  });
+
+  it('should ignore when head of keys equals to defaultVariantSuffix', () => {
+    expect(
+      pickupFromVariantKey(
+        {
+          delay: 10,
+          defaultVariantSuffix: 'iPhone 6',
+          viewport: 'iPhone 6',
+          variants: {
+            k1: {
+              delay: 100,
+            },
+          },
+        },
+        { isDefault: false, keys: ['iPhone 6', 'k1'] },
       ),
     ).toEqual({
       delay: 100,
       viewport: 'iPhone 6',
+      defaultVariantSuffix: 'iPhone 6',
     });
   });
 });

--- a/src/util/screenshot-options-helper.ts
+++ b/src/util/screenshot-options-helper.ts
@@ -95,7 +95,7 @@ export type VariantKeyNotFound = {
 
 export type InvalidVariantKeysReference = CircularVariantRef | VariantKeyNotFound;
 
-export function extractAdditionalVariantKeys({
+export function extractVariantKeys({
   variants,
   defaultVariantSuffix,
 }: ScreenshotOptions): [InvalidVariantKeysReference | null, VariantKey[]] {

--- a/src/util/screenshot-options-helper.ts
+++ b/src/util/screenshot-options-helper.ts
@@ -82,9 +82,63 @@ export function mergeScreenshotOptions<T extends ScreenshotOptions>(base: T, fra
   return ret;
 }
 
-export function extractAdditionalVariantKeys<T extends ScreenshotOptions>(options: T): VariantKey[] {
-  if (!options.variants) return [];
-  return Object.keys(options.variants).map(k => ({ isDefault: false, keys: [k] }));
+export type CircularVariantRef = {
+  type: 'circular';
+  refs: string[];
+};
+
+export type VariantKeyNotFound = {
+  type: 'notFound';
+  from: string;
+  to: string;
+};
+
+export type InvalidVariantKeysReference = CircularVariantRef | VariantKeyNotFound;
+
+export function extractAdditionalVariantKeys({
+  variants,
+  defaultVariantSuffix,
+}: ScreenshotOptions): [InvalidVariantKeysReference | null, VariantKey[]] {
+  if (!variants) return [null, []];
+  let invalidReason: InvalidVariantKeysReference | undefined = undefined;
+  const ret = Object.keys(variants).reduce(
+    (acc, key) => {
+      const keysList: string[][] = [];
+      const getParentKeys = (currentKey: string, childrenKeys: string[] = []): boolean => {
+        if (defaultVariantSuffix && defaultVariantSuffix === currentKey) {
+          keysList.push([currentKey, ...childrenKeys]);
+          return true;
+        }
+        if (!variants[currentKey]) {
+          invalidReason = {
+            type: 'notFound',
+            from: childrenKeys[0],
+            to: currentKey,
+          };
+          return false;
+        }
+        if (childrenKeys.find(k => k === currentKey)) {
+          invalidReason = {
+            type: 'circular',
+            refs: [currentKey, ...childrenKeys],
+          };
+          return false;
+        }
+        const parent = variants![currentKey].extends;
+        const parentKeys = Array.isArray(parent) ? parent : typeof parent === 'string' ? [parent] : [];
+        if (!parentKeys.length) {
+          keysList.push([currentKey, ...childrenKeys]);
+          return true;
+        }
+        return parentKeys.every(pk => getParentKeys(pk, [currentKey, ...childrenKeys]));
+      };
+      getParentKeys(key);
+      return [...acc, ...keysList.map(keys => ({ isDefault: false, keys }))];
+    },
+    [] as VariantKey[],
+  );
+  if (!invalidReason) return [null, ret];
+  return [invalidReason, []];
 }
 
 export function pickupFromVariantKey(options: ScreenshotOptions, vk: VariantKey): ScreenshotOptions {
@@ -92,5 +146,8 @@ export function pickupFromVariantKey(options: ScreenshotOptions, vk: VariantKey)
   const base = Object.assign({}, options);
   const variants = base.variants || {};
   delete base.variants;
-  return vk.keys.reduce((acc: ScreenshotOptionFragments, key) => mergeScreenshotOptions(acc, variants[key]), base);
+  const offset = vk.keys[0] && vk.keys[0] === options.defaultVariantSuffix ? 1 : 0;
+  return vk.keys
+    .slice(offset)
+    .reduce((acc: ScreenshotOptionFragments, key) => mergeScreenshotOptions(acc, variants[key]), base);
 }


### PR DESCRIPTION
## What I did

Introduce `extends` keyword into variants definition.

```js
screenshot: {
  variants: {
    iPad: { viewport: 'iPad' },
    hover: {
      hover: 'button',
      extends: 'iPad',
  },
}
```

For example, the above options generates:

- `some_kind/some_story.png` (default variant
- `some_kind/some_story_iPad.png`
- `some_kind/some_story_iPad_hover.png`

See also #95  (originally it was named as `followWith` ) 